### PR TITLE
Update prtime to enable combining of output with other streams

### DIFF
--- a/README
+++ b/README
@@ -29,3 +29,10 @@ INSTALLATION INSTRUCTIONS
     
   To run the software enter :
     $ ms8236usb
+
+CORRELATING WITH OTHER STREAMS
+Multimeter readings can be combined with another log or stream source uinsg a third party tool [lmerge](https://github.com/rianhunter/lmerge) as follows:
+```
+lmerge <(tail -n1 -f /path/to/file) <(ms8236usb) | tee /tmp/combined-output
+```
+`tail` can be replaced by anything streaming to `STDOUT`.

--- a/ms8236usb.c
+++ b/ms8236usb.c
@@ -92,6 +92,7 @@ void prtime(void)
 
     /* Print to stdout. ctime() has already added a terminating newline character. */
     (void) printf("%s", c_time_string);
+    fflush(stdout);
 }
 
 void 	decode_digit(unsigned char raw_digit )


### PR DESCRIPTION
Updated `prtime` to add `flush` such that the output from `ms8236usb` can be combined with other piped streams.
Added example of this to the README.